### PR TITLE
Revert "rtu: skip zero bytes before response on purpose (#1)"

### DIFF
--- a/src/modbus.c
+++ b/src/modbus.c
@@ -344,7 +344,6 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
     struct timeval *p_tv;
     int length_to_read;
     int msg_length = 0;
-    int receiving_noise = 1;
     _step_t step;
 
     if (ctx->debug) {
@@ -381,66 +380,6 @@ int _modbus_receive_msg(modbus_t *ctx, uint8_t *msg, msg_type_t msg_type)
         tv.tv_sec = ctx->response_timeout.tv_sec;
         tv.tv_usec = ctx->response_timeout.tv_usec;
         p_tv = &tv;
-    }
-
-    // skip noise zeros before message
-    while (receiving_noise > 0) {
-        rc = ctx->backend->select(ctx, &rset, p_tv, 1);
-        if (rc == -1) {
-            _error_print(ctx, "select");
-            if (ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) {
-                int saved_errno = errno;
-
-                if (errno == ETIMEDOUT) {
-                    _sleep_response_timeout(ctx);
-                    modbus_flush(ctx);
-                } else if (errno == EBADF) {
-                    modbus_close(ctx);
-                    modbus_connect(ctx);
-                }
-                errno = saved_errno;
-            }
-            return -1;
-        }
-
-        uint8_t tmp_data;
-        rc = ctx->backend->recv(ctx, &tmp_data, 1);
-        if (rc == 0) {
-            errno = ECONNRESET;
-            rc = -1;
-        }
-
-        if (rc == -1) {
-            _error_print(ctx, "read");
-            if ((ctx->error_recovery & MODBUS_ERROR_RECOVERY_LINK) &&
-                (errno == ECONNRESET || errno == ECONNREFUSED ||
-                 errno == EBADF)) {
-                int saved_errno = errno;
-                modbus_close(ctx);
-                modbus_connect(ctx);
-                /* Could be removed by previous calls */
-                errno = saved_errno;
-            }
-            return -1;
-        }
-
-        if (ctx->debug) {
-            printf("[noise skip] read: %.2X\n", tmp_data);
-        }
-
-        if (tmp_data != 0x00) {
-            msg[msg_length] = tmp_data;
-            msg_length++;
-            length_to_read--;
-            receiving_noise = 0;
-            if (ctx->debug) {
-                printf("<%.2X>", tmp_data);
-            }
-        } else {
-            if (ctx->debug) {
-                printf("Received a zero byte before response, skipping it on purpose\n");
-            }
-        }
     }
 
     while (length_to_read != 0) {


### PR DESCRIPTION
This reverts commit 1f5d8fa8ea7866a2b20ab1ae3c47a3f1dd370375.

Отменил коммит с фиксом. Теперь прошивка по нулевому адресу работает, проверил на WB6 и WB7. На текущем флешере не работает, нулевой адрес в ответе принимается за шум:
```
Sending info block...[00][10][10][00][00][10][20][DF][88][15][73][E3][79][51][CB][DC][74][2E][3A][47][63][83][BC][EC][2B][77][33][B2][7B][10][93][7A][67][42][17][70][93][C9][05][94][FA]
Waiting for a confirmation...
[noise skip] read: 00
Received a zero byte before response, skipping it on purpose
[noise skip] read: 10
ERROR Connection timed out: select
<10><10><00><00><10><C4><D4>
Error while sending info block: Connection timed out
```